### PR TITLE
StructClass may not provide any non own classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+#Ignore Mac OS X DS Store
+.DS_Store
+
+*~
+*.swp
+.project
+.settings
+.classpath
+
+# Ignore all build/dist directories
+target
+out
+fernflower.jar
+
+# Ignore InteliJ Idea project files
+.idea
+.idea/*
+*.iml
+*.iws
+*.ipr
+
+# Ignore all log files
+*.log

--- a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
+++ b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
@@ -55,8 +55,8 @@ public class ClassesProcessor {
     boolean bDecompileInner = DecompilerContext.getOption(IFernflowerPreferences.DECOMPILE_INNER);
 
     // create class nodes
-    for (StructClass cl : context.getClasses().values()) {
-      if (cl.isOwn() && !mapRootClasses.containsKey(cl.qualifiedName)) {
+    for (StructClass cl : context.getOwnClasses().values()) {
+      if (!mapRootClasses.containsKey(cl.qualifiedName)) {
 
         if (bDecompileInner) {
           StructInnerClassesAttribute inner = (StructInnerClassesAttribute)cl.getAttributes().getWithKey("InnerClasses");
@@ -104,7 +104,7 @@ public class ClassesProcessor {
               }
 
               if (!innername.equals(enclClassName)) {  // self reference
-                StructClass enclosing_class = context.getClasses().get(enclClassName);
+                StructClass enclosing_class = context.getClass(enclClassName);
                 if (enclosing_class != null && enclosing_class.isOwn()) { // own classes only
 
                   Object[] arrold = mapInnerClasses.get(innername);

--- a/src/org/jetbrains/java/decompiler/modules/renamer/IdentifierConverter.java
+++ b/src/org/jetbrains/java/decompiler/modules/renamer/IdentifierConverter.java
@@ -187,7 +187,7 @@ public class IdentifierConverter implements NewClassNameBuilder {
         String classname = helper.getNextClassName(classOldFullName, ConverterHelper.getSimpleClassName(classOldFullName));
         classNewFullName = ConverterHelper.replaceSimpleClassName(classOldFullName, classname);
       }
-      while (context.getClasses().containsKey(classNewFullName));
+      while (context.getClass(classNewFullName) != null);
 
       interceptor.addName(classOldFullName, classNewFullName);
     }
@@ -327,16 +327,11 @@ public class IdentifierConverter implements NewClassNameBuilder {
 
   private void buildInheritanceTree() {
     Map<String, ClassWrapperNode> nodes = new HashMap<String, ClassWrapperNode>();
-    Map<String, StructClass> classes = context.getClasses();
 
     List<ClassWrapperNode> rootClasses = new ArrayList<ClassWrapperNode>();
     List<ClassWrapperNode> rootInterfaces = new ArrayList<ClassWrapperNode>();
 
-    for (StructClass cl : classes.values()) {
-      if (!cl.isOwn()) {
-        continue;
-      }
-
+    for (StructClass cl : context.getOwnClasses().values()) {
       LinkedList<StructClass> stack = new LinkedList<StructClass>();
       LinkedList<ClassWrapperNode> stackSubNodes = new LinkedList<ClassWrapperNode>();
 
@@ -368,7 +363,7 @@ public class IdentifierConverter implements NewClassNameBuilder {
 
           if (isInterface) {
             for (String ifName : clStr.getInterfaceNames()) {
-              StructClass clParent = classes.get(ifName);
+              StructClass clParent = context.getClass(ifName);
               if (clParent != null) {
                 stack.add(clParent);
                 stackSubNodes.add(node);
@@ -377,7 +372,7 @@ public class IdentifierConverter implements NewClassNameBuilder {
             }
           }
           else if (clStr.superClass != null) { // null iff java/lang/Object
-            StructClass clParent = classes.get(clStr.superClass.getString());
+            StructClass clParent = context.getClass(clStr.superClass.getString());
             if (clParent != null) {
               stack.add(clParent);
               stackSubNodes.add(node);

--- a/src/org/jetbrains/java/decompiler/struct/StructContext.java
+++ b/src/org/jetbrains/java/decompiler/struct/StructContext.java
@@ -23,9 +23,11 @@ import org.jetbrains.java.decompiler.util.InterpreterUtil;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.jar.JarFile;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -49,6 +51,16 @@ public class StructContext {
 
   public StructClass getClass(String name) {
     return classes.get(name);
+  }
+  
+  public Map<String, StructClass> getOwnClasses() {
+      Map<String, StructClass> ownClasses = new HashMap<String, StructClass>();
+      for(Entry<String, StructClass> entry : classes.entrySet()) {
+          if(entry.getValue().isOwn()) {
+              ownClasses.put(entry.getKey(), entry.getValue());
+          }
+      }
+      return Collections.unmodifiableMap(ownClasses);
   }
 
   public void reloadContext() throws IOException {
@@ -181,9 +193,5 @@ public class StructContext {
     finally {
       archive.close();
     }
-  }
-
-  public Map<String, StructClass> getClasses() {
-    return classes;
   }
 }


### PR DESCRIPTION
If StructClass provide a map contains all classes. Then will cause we got a huge map if we have too much libraries. And if we want to create a custom loader to load classes at time of we need. This will cause we have no way to do that. Because we must provide class files use addSpace before decompile start.

Sorry for my poor English :p
