### PR TITLE
Fix for clinit and USE_DEBUG_LINE_NUMBERS

### DIFF
--- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
+++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
@@ -231,19 +231,22 @@ public class ClassWriter {
 
       VBStyleCollection<StructMethod, String> methods = cl.getMethods();
 
-      /* if clinit was originally located at the top of a class it will have been moved to the bottom, the linenumbertable however will contain the original numbers.
-         If this is the case when USE_DEBUG_LINE_NUMBERS is enabled, the clinit method must be moved back to the top of the list to prevent incorrect mapping of lines.
+       /*if clinit was not originally located at the bottom of the class, it will have been moved to the bottom, the linenumbertable however will contain the original numbers.
+         If this is the case when USE_DEBUG_LINE_NUMBERS is enabled, the clinit method must be moved back to its original position in the methods list to prevent incorrect mapping of lines.
        */
-      if( methods.getLast().hasModifier(CodeConstants.ACC_STATIC) && DecompilerContext.getOption(IFernflowerPreferences.USE_DEBUG_LINE_NUMBERS)  )
+      if( CodeConstants.CLINIT_NAME.equals(methods.getLast().getName()) && DecompilerContext.getOption(IFernflowerPreferences.USE_DEBUG_LINE_NUMBERS)  )
       {
-        int firstMethodFirstLine = ((StructLineNumberTableAttribute)cl.getMethods().get(1).getAttributes().
-                getWithKey(StructGeneralAttribute.ATTRIBUTE_LINE_NUMBER_TABLE)).getFirstLine();
         int staticFirstLine = ((StructLineNumberTableAttribute)methods.getLast().getAttributes().
                 getWithKey(StructGeneralAttribute.ATTRIBUTE_LINE_NUMBER_TABLE)).getFirstLine();
 
-        if( staticFirstLine < firstMethodFirstLine)
+        for( int j = 1; j < methods.size() -1; j++ )
         {
-          methods.add( 1, methods.remove( methods.size() - 1 ) );
+          if( staticFirstLine < ((StructLineNumberTableAttribute) methods.get(j).getAttributes().
+                  getWithKey(StructGeneralAttribute.ATTRIBUTE_LINE_NUMBER_TABLE)).getFirstLine() )
+          {
+            methods.add( j, methods.remove( methods.size() - 1) );
+            break;
+          }
         }
       }
 

--- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
+++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
@@ -42,6 +42,7 @@ import org.jetbrains.java.decompiler.struct.gen.MethodDescriptor;
 import org.jetbrains.java.decompiler.struct.gen.VarType;
 import org.jetbrains.java.decompiler.struct.gen.generics.*;
 import org.jetbrains.java.decompiler.util.InterpreterUtil;
+import org.jetbrains.java.decompiler.util.VBStyleCollection;
 
 import java.util.*;
 
@@ -227,8 +228,27 @@ public class ClassWriter {
       // FIXME: fields don't matter at the moment
       startLine += buffer.countLines(start_class_def);
 
+
+      VBStyleCollection<StructMethod, String> methods = cl.getMethods();
+
+      /* if clinit was originally located at the top of a class it will have been moved to the bottom, the linenumbertable however will contain the original numbers.
+         If this is the case when USE_DEBUG_LINE_NUMBERS is enabled, the clinit method must be moved back to the top of the list to prevent incorrect mapping of lines.
+       */
+      if( methods.getLast().hasModifier(CodeConstants.ACC_STATIC) && DecompilerContext.getOption(IFernflowerPreferences.USE_DEBUG_LINE_NUMBERS)  )
+      {
+        int firstMethodFirstLine = ((StructLineNumberTableAttribute)cl.getMethods().get(1).getAttributes().
+                getWithKey(StructGeneralAttribute.ATTRIBUTE_LINE_NUMBER_TABLE)).getFirstLine();
+        int staticFirstLine = ((StructLineNumberTableAttribute)methods.getLast().getAttributes().
+                getWithKey(StructGeneralAttribute.ATTRIBUTE_LINE_NUMBER_TABLE)).getFirstLine();
+
+        if( staticFirstLine < firstMethodFirstLine)
+        {
+          methods.add( 1, methods.remove( methods.size() - 1 ) );
+        }
+      }
+
       // methods
-      for (StructMethod mt : cl.getMethods()) {
+      for ( StructMethod mt : methods ) {
         boolean hide = mt.isSynthetic() && DecompilerContext.getOption(IFernflowerPreferences.REMOVE_SYNTHETIC) ||
                        mt.hasModifier(CodeConstants.ACC_BRIDGE) && DecompilerContext.getOption(IFernflowerPreferences.REMOVE_BRIDGE) ||
                        wrapper.getHiddenMembers().contains(InterpreterUtil.makeUniqueKey(mt.getName(), mt.getDescriptor()));
@@ -655,7 +675,7 @@ public class ClassWriter {
           init = true;
         }
       }
-      else if (CodeConstants.CLINIT_NAME.equals(name)) {
+      else if ( CodeConstants.CLINIT_NAME.equals(name) ) {
         name = "";
         clinit = true;
       }
@@ -835,7 +855,7 @@ public class ClassWriter {
         // We do not have line information for method start, lets have it here for now
         StructLineNumberTableAttribute lineNumberTable =
           (StructLineNumberTableAttribute)mt.getAttributes().getWithKey(StructGeneralAttribute.ATTRIBUTE_LINE_NUMBER_TABLE);
-        if (lineNumberTable != null && DecompilerContext.getOption(IFernflowerPreferences.USE_DEBUG_LINE_NUMBERS)) {
+        if (lineNumberTable != null && DecompilerContext.getOption(IFernflowerPreferences.USE_DEBUG_LINE_NUMBERS) ) {
           buffer.setCurrentLine(lineNumberTable.getFirstLine() - 1);
         }
         buffer.append('{').appendLineSeparator();


### PR DESCRIPTION
The current code caused all methods to get crushed onto a single line when a static block was located anywhere other than the bottom of the class and the USE_DEBUG_LINE_NUMBERS flag was enabled. This change simply moves the block back to the correct position in order to prevent this case.