### PR TITLE
overloaded_methods_and_params_fix

### DIFF
--- a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
@@ -891,15 +891,15 @@ public class ExprProcessor implements CodeConstants {
                                          TextBuffer buffer,
                                          int indent,
                                          boolean castNull,
-                                         boolean castAlways,
+                                         boolean requiresExactTypeMatch,
                                          BytecodeMappingTracer tracer) {
 
     VarType rightType = exprent.getExprType();
 
     TextBuffer res = exprent.toJava(indent, tracer);
-
+    
     boolean cast =
-      castAlways ||
+      (requiresExactTypeMatch && !leftType.equals(exprent.getExprType())) ||
       (!leftType.isSuperset(rightType) && (rightType.equals(VarType.VARTYPE_OBJECT) || leftType.type != CodeConstants.TYPE_OBJECT)) ||
       (castNull && rightType.type == CodeConstants.TYPE_NULL && !UNDEFINED_TYPE_STRING.equals(getTypeName(leftType))) ||
       (isIntConstant(exprent) && VarType.VARTYPE_INT.isStrictSuperset(leftType));

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
@@ -261,13 +261,25 @@ public class ConstExprent extends Exprent {
             String strval = value.toString();
 
             VarType classtype;
-            if (strval.startsWith("[")) { // array of simple type
-              classtype = new VarType(strval, false);
+            
+            //we must check renamer...
+            String lookupName = strval;
+            if (lookupName.charAt(0) == '[') {
+                lookupName = lookupName.substring(1);
             }
-            else { // class
-              classtype = new VarType(strval, true);
+            lookupName = lookupName.replace('.', '/');
+            String newName = DecompilerContext.getPoolInterceptor().getName(lookupName);
+            if (newName != null) {
+                strval = newName;
             }
 
+            if (strval.startsWith("[")) { // array of simple type
+                classtype = new VarType(strval, false);
+            }
+              else { // class
+                classtype = new VarType(strval, true);
+            }
+            
             return new TextBuffer(ExprProcessor.getCastTypeName(classtype)).append(".class");
           }
       }

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FieldExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FieldExprent.java
@@ -124,7 +124,7 @@ public class FieldExprent extends Exprent {
       }
       else {
         TextBuffer buff = new TextBuffer();
-        boolean casted = ExprProcessor.getCastedExprent(instance, new VarType(CodeConstants.TYPE_OBJECT, 0, classname), buff, indent, true, tracer);
+        boolean casted = ExprProcessor.getCastedExprent(instance, new VarType(CodeConstants.TYPE_OBJECT, 0, classname), buff, indent, true, true, tracer);
         String res = buff.toString();
 
         if (casted || instance.getPrecedence() > getPrecedence()) {

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java
@@ -225,7 +225,7 @@ public class NewExprent extends Exprent {
               }
             }
 
-            ExprProcessor.getCastedExprent(param, invSuper.getDescriptor().params[i], buf, indent, true, tracer);
+            ExprProcessor.getCastedExprent(param, invSuper.getDescriptor().params[i], buf, indent, true, true, tracer);
 
             firstParam = false;
           }


### PR DESCRIPTION
Fix for IDEA-135385:
Overloaded and hidden fields and methods caused errors. All parameters and the caller type must match the descriptor exactly, if not a cast is needed. The reason is that the current instance could have been cast to a sub/super class in the original code and we cannot know that. And we don't know if the method/field is overloaded on that subclass.