### PR TITLE
Markdown README and LICENCE files

### DIFF
--- a/LICENCE.md
+++ b/LICENCE.md
@@ -1,0 +1,195 @@
+Apache License
+==============
+
+_Version 2.0, January 2004_  
+_&lt;<http://www.apache.org/licenses/>&gt;_
+
+### Terms and Conditions for use, reproduction, and distribution
+
+#### 1. Definitions
+
+“License” shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+“Licensor” shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+“Legal Entity” shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, “control” means **(i)** the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or **(ii)** ownership of fifty percent (50%) or more of the
+outstanding shares, or **(iii)** beneficial ownership of such entity.
+
+“You” (or “Your”) shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+“Source” form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+“Object” form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+“Work” shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+“Derivative Works” shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+“Contribution” shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+“submitted” means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as “Not a Contribution.”
+
+“Contributor” shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+#### 2. Grant of Copyright License
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and such
+Derivative Works in Source or Object form.
+
+#### 3. Grant of Patent License
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by such Contributor
+that are necessarily infringed by their Contribution(s) alone or by combination
+of their Contribution(s) with the Work to which such Contribution(s) was
+submitted. If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+Contribution incorporated within the Work constitutes direct or contributory
+patent infringement, then any patent licenses granted to You under this License
+for that Work shall terminate as of the date such litigation is filed.
+
+#### 4. Redistribution
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof
+in any medium, with or without modifications, and in Source or Object form,
+provided that You meet the following conditions:
+
+* **(a)** You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+* **(b)** You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+* **(c)** You must retain, in the Source form of any Derivative Works that You distribute,
+all copyright, patent, trademark, and attribution notices from the Source form
+of the Work, excluding those notices that do not pertain to any part of the
+Derivative Works; and
+* **(d)** If the Work includes a “NOTICE” text file as part of its distribution, then any
+Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents of
+the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+#### 5. Submission of Contributions
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted
+for inclusion in the Work by You to the Licensor shall be under the terms and
+conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the terms of
+any separate license agreement you may have executed with Licensor regarding
+such Contributions.
+
+#### 6. Trademarks
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+#### 7. Disclaimer of Warranty
+
+Unless required by applicable law or agreed to in writing, Licensor provides the
+Work (and each Contributor provides its Contributions) on an “AS IS” BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+solely responsible for determining the appropriateness of using or
+redistributing the Work and assume any risks associated with Your exercise of
+permissions under this License.
+
+#### 8. Limitation of Liability
+
+In no event and under no legal theory, whether in tort (including negligence),
+contract, or otherwise, unless required by applicable law (such as deliberate
+and grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special, incidental,
+or consequential damages of any character arising as a result of this License or
+out of the use or inability to use the Work (including but not limited to
+damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+any and all other commercial damages or losses), even if such Contributor has
+been advised of the possibility of such damages.
+
+#### 9. Accepting Warranty or Additional Liability
+
+While redistributing the Work or Derivative Works thereof, You may choose to
+offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this License. However,
+in accepting such obligations, You may act only on Your own behalf and on Your
+sole responsibility, not on behalf of any other Contributor, and only if You
+agree to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+_END OF TERMS AND CONDITIONS_
+
+### APPENDIX: How to apply the Apache License to your work
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets `[]` replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same “printed page” as the copyright notice for easier identification within
+third-party archives.
+
+    Copyright [yyyy] [name of copyright owner]
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+      http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ fernflower.decompiler@gmail.com
 
 ## Licence
 
-Fernflower is licenced under the (http://www.apache.org/licenses/LICENSE-2.0)[Apache Licence Version 2.0]
+Fernflower is licenced under [http://www.apache.org/licenses/LICENSE-2.0)](Apache Licence Version 2.0)
 
 ## Running from command line
 

--- a/README.md
+++ b/README.md
@@ -39,56 +39,31 @@ Typically, the following options will be changed by user, if any: hes, hdc, dgs,
 The rest of options can be left as they are: they are aimed at professional reverse engineers.
 
 - rbr (1): hide bridge methods
-
 - rsy (0): hide synthetic class members
-
 - din (1): decompile inner classes
-
 - dc4 (1): collapse 1.4 class references
-
 - das (1): decompile assertions
-
 - hes (1): hide empty super invocation
-
 - hdc (1): hide empty default constructor
-
 - dgs (0): decompile generic signatures
-
 - ner (1): assume return not throwing exceptions
-
 - den (1): decompile enumerations
-
 - rgn (1): remove getClass() invocation, when it is part of a qualified new statement
-
 - lit (0): output numeric literals "as-is"
-
 - asc (0): encode non-ASCII characters in string and character literals as Unicode escapes
-
 - bto (1): interpret int 1 as boolean true (workaround to a compiler bug)
-
 - nns (1): allow for not set synthetic attribute (workaround to a compiler bug)
-
 - uto (1): consider nameless types as java.lang.Object (workaround to a compiler architecture flaw)
-
 - udv (1): reconstruct variable names from debug information, if present
-
 - rer (1): remove empty exception ranges
-
 - fdi (1): de-inline finally structures
-
 - mpm (0): maximum allowed processing time per decompiled method, in seconds. 0 means no upper limit
-
 - ren (0): rename ambiguous (resp. obfuscated) classes and class elements
-
 - urc    : full name of user-supplied class implementing IIdentifierRenamer. It is used to determine which class identifiers
          should be renamed and provides new identifier names. For more information see section 5
-
 - inn (1): check for IntelliJ IDEA-specific @NotNull annotation and remove inserted code if found
-
 - lac (0): decompile lambda expressions to anonymous classes
-
 - nls (0): define new line character to be used for output. 0 - '\r\n' (Windows), 1 - '\n' (Unix), default is OS-dependent
-
 - ind    : indentation string (default is "   " (3 spaces))
  
 The default logging level is INFO. This value can be overwritten by setting the option 'log' as follows:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ fernflower.decompiler@gmail.com
 
 ## Licence
 
-Fernflower is licenced under [http://www.apache.org/licenses/LICENSE-2.0)](Apache Licence Version 2.0)
+Fernflower is licenced under (Apache Licence Version 2.0)[http://www.apache.org/licenses/LICENSE-2.0]
 
 ## Running from command line
 

--- a/README.md
+++ b/README.md
@@ -38,33 +38,58 @@ value, if any, is given between parentheses.
 Typically, the following options will be changed by user, if any: hes, hdc, dgs, mpm, ren, urc 
 The rest of options can be left as they are: they are aimed at professional reverse engineers.
 
-rbr (1): hide bridge methods
-rsy (0): hide synthetic class members
-din (1): decompile inner classes
-dc4 (1): collapse 1.4 class references
-das (1): decompile assertions
-hes (1): hide empty super invocation
-hdc (1): hide empty default constructor
-dgs (0): decompile generic signatures
-ner (1): assume return not throwing exceptions
-den (1): decompile enumerations
-rgn (1): remove getClass() invocation, when it is part of a qualified new statement
-lit (0): output numeric literals "as-is"
-asc (0): encode non-ASCII characters in string and character literals as Unicode escapes
-bto (1): interpret int 1 as boolean true (workaround to a compiler bug)
-nns (1): allow for not set synthetic attribute (workaround to a compiler bug)
-uto (1): consider nameless types as java.lang.Object (workaround to a compiler architecture flaw)
-udv (1): reconstruct variable names from debug information, if present
-rer (1): remove empty exception ranges
-fdi (1): de-inline finally structures
-mpm (0): maximum allowed processing time per decompiled method, in seconds. 0 means no upper limit
-ren (0): rename ambiguous (resp. obfuscated) classes and class elements
-urc    : full name of user-supplied class implementing IIdentifierRenamer. It is used to determine which class identifiers
+- rbr (1): hide bridge methods
+
+- rsy (0): hide synthetic class members
+
+- din (1): decompile inner classes
+
+- dc4 (1): collapse 1.4 class references
+
+- das (1): decompile assertions
+
+- hes (1): hide empty super invocation
+
+- hdc (1): hide empty default constructor
+
+- dgs (0): decompile generic signatures
+
+- ner (1): assume return not throwing exceptions
+
+- den (1): decompile enumerations
+
+- rgn (1): remove getClass() invocation, when it is part of a qualified new statement
+
+- lit (0): output numeric literals "as-is"
+
+- asc (0): encode non-ASCII characters in string and character literals as Unicode escapes
+
+- bto (1): interpret int 1 as boolean true (workaround to a compiler bug)
+
+- nns (1): allow for not set synthetic attribute (workaround to a compiler bug)
+
+- uto (1): consider nameless types as java.lang.Object (workaround to a compiler architecture flaw)
+
+- udv (1): reconstruct variable names from debug information, if present
+
+- rer (1): remove empty exception ranges
+
+- fdi (1): de-inline finally structures
+
+- mpm (0): maximum allowed processing time per decompiled method, in seconds. 0 means no upper limit
+
+- ren (0): rename ambiguous (resp. obfuscated) classes and class elements
+
+- urc    : full name of user-supplied class implementing IIdentifierRenamer. It is used to determine which class identifiers
          should be renamed and provides new identifier names. For more information see section 5
-inn (1): check for IntelliJ IDEA-specific @NotNull annotation and remove inserted code if found
-lac (0): decompile lambda expressions to anonymous classes
-nls (0): define new line character to be used for output. 0 - '\r\n' (Windows), 1 - '\n' (Unix), default is OS-dependent
-ind    : indentation string (default is "   " (3 spaces))
+
+- inn (1): check for IntelliJ IDEA-specific @NotNull annotation and remove inserted code if found
+
+- lac (0): decompile lambda expressions to anonymous classes
+
+- nls (0): define new line character to be used for output. 0 - '\r\n' (Windows), 1 - '\n' (Unix), default is OS-dependent
+
+- ind    : indentation string (default is "   " (3 spaces))
  
 The default logging level is INFO. This value can be overwritten by setting the option 'log' as follows:
 log (INFO): possible values TRACE, INFO, WARN, ERROR

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-1. About the decompiler 
+## About fernflower
 
 Fernflower is the first actually working analytical decompiler for Java and 
 probably for a high-level programming language in general. Naturally it is still 
@@ -6,12 +6,11 @@ under development, please send your bug reports and improvement suggestions at
 fernflower.decompiler@gmail.com
 
 
-2. License
+## Licence
 
-http://www.apache.org/licenses/LICENSE-2.0
+Fernflower is licenced under the (http://www.apache.org/licenses/LICENSE-2.0)[Apache Licence Version 2.0]
 
-
-3. Running from the command line
+## Running from command line
 
 java -jar fernflower.jar [-<option>=<value>]* [<source>]+ <destination>
 
@@ -24,14 +23,14 @@ java -jar fernflower.jar [-<option>=<value>]* [<source>]+ <destination>
 <destination>: destination directory 
 <option>,<value>: command line option with the corresponding value, see 4.
 
-Examples:
+### Examples
 
 java -jar fernflower.jar -hes=0 -hdc=0 c:\Temp\binary\ -e=c:\Java\rt.jar c:\Temp\source\
 
 java -jar fernflower.jar -dgs=1 c:\Temp\binary\library.jar c:\Temp\binary\Boot.class c:\Temp\source\
 
 
-4. Command line options
+## Command line options
 
 With the exception of mpm and urc the value of 1 means the option is activated, 0 - deactivated. Default 
 value, if any, is given between parentheses.
@@ -71,7 +70,7 @@ The default logging level is INFO. This value can be overwritten by setting the 
 log (INFO): possible values TRACE, INFO, WARN, ERROR
 
 
-5. Renaming identifiers
+## Renaming identifiers
 
 Some obfuscators give classes and their member elements short, meaningless and above all ambiguous names. Recompiling of such
 code leads to a great number of conflicts. Therefore it is advisable to let the decompiler rename elements in its turn, 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ fernflower.decompiler@gmail.com
 
 ## Licence
 
-Fernflower is licenced under (http://www.apache.org/licenses/LICENSE-2.0)[Apache Licence Version 2.0]
+Fernflower is licenced under the Apache Licence Version 2.0. It can be found here: http://www.apache.org/licenses/LICENSE-2.0
 
 ## Running from command line
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ fernflower.decompiler@gmail.com
 
 ## Licence
 
-Fernflower is licenced under (Apache Licence Version 2.0)[http://www.apache.org/licenses/LICENSE-2.0]
+Fernflower is licenced under (http://www.apache.org/licenses/LICENSE-2.0)[Apache Licence Version 2.0]
 
 ## Running from command line
 


### PR DESCRIPTION
This PR rewrites the README file in markdown format and adds the Apache Licence 2.0 as LICENCE.md (also markdown). That's pretty much it :P